### PR TITLE
Add Promises/A+ Compliance Test Suite

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A proper compact promise (promises/A+ spec compliant) library.",
   "main": "promiz.js",
   "scripts": {
+    "spec": "promises-aplus-tests test-adapter",
     "test": "jasmine-node ."
   },
   "repository": {
@@ -23,6 +24,9 @@
     "async",
     "flow control"
   ],
+  "devDependencies": {
+    "promises-aplus-tests": "2.0.x"
+  },
   "author": "Zolmeister",
   "license": "MIT",
   "gitHead": "381d65d8abe30f2077f3f9d7ccdcb41e58a8fb5a"

--- a/test-adapter.js
+++ b/test-adapter.js
@@ -1,0 +1,6 @@
+var Promiz = require('./promiz');
+module.exports = {
+  resolved: function (value) { d = Promiz.defer(); d.resolve(value); return d; },
+  rejected: function (error) { d = Promiz.defer(); d.reject(error);  return d; },
+  deferred: Promiz.defer,
+};


### PR DESCRIPTION
The README mentions that Promiz.js is Promises/A+ spec compliant.
The way to verify this is the [Promises/A+ Compliance Test Suite](https://github.com/promises-aplus/promises-tests).

This pull requests adds an adapter for this suite, which can now be ran with:

``` bash
$ npm run spec
```

**Unfortunately, the Promiz.js library does not pass the Promises/A+ suite.**
At least 624 tests of the 872 tests are failing—the code hangs after the 624th failure, so there might be more.

Would it be possible to adapt Promiz.js such that it becomes Promises/A+ spec compatible,
or alternatively, could you mention in the README that it's not?
It's perfectly fine not to be compatible, but to avoid confusion, it should be mentioned correctly.
