### PR TITLE
Next shouldn't keep on growing

### DIFF
--- a/promiz.micro.js
+++ b/promiz.micro.js
@@ -37,12 +37,14 @@
 
     self['then'] = function (fn, er) {
       var p = new promise(fn, er)
-      next.push(p)
       if (state == 3) {
         p.resolve(val)
       }
-      if (state == 4) {
+      else if (state == 4) {
         p.reject(val)
+      }
+      else {
+        next.push(p)
       }
       return p
     }
@@ -56,11 +58,12 @@
         })
       }
 
-      if (state == 4) {
+      else if (state == 4) {
         next.map(function (p) {
           p.reject(val)
         })
       }
+      next = []
     }
 
     // ref : reference to 'then' function
@@ -113,7 +116,7 @@
             val = fn(val)
           }
 
-          if (state == 2 && typeof er == 'function') {
+          else if (state == 2 && typeof er == 'function') {
             val = er(val)
             state = 1
           }


### PR DESCRIPTION
As far as I can tell, `next` keeps on growing, which can become a problem quickly.
This suggested fix only pushes to `next` when necessary, and clears it when not used.
`else`s have been added to keep the code at the same gzipped size (238 bytes).
In addition, it makes the library a little faster (theoretically).

Warning: even though it passes the spec, I'm not sure whether `next` is allowed to be cleared;
I got errors when I set it to `null`. I think the current version is harmless though, but please verify.
