### PR TITLE
Only export the deferred function.

### DIFF
--- a/promiz.micro.js
+++ b/promiz.micro.js
@@ -3,7 +3,7 @@
   /**
    * @constructor
    */
-  function promise(fn, er) {
+  function Deferred(fn, er) {
     // states
     // 0: pending
     // 1: resolving
@@ -36,17 +36,17 @@
     }
 
     self['then'] = function (fn, er) {
-      var p = new promise(fn, er)
+      var d = new Deferred(fn, er)
       if (state == 3) {
-        p.resolve(val)
+        d.resolve(val)
       }
       else if (state == 4) {
-        p.reject(val)
+        d.reject(val)
       }
       else {
-        next.push(p)
+        next.push(d)
       }
-      return p
+      return d
     }
 
     var finish = function (type) {
@@ -68,7 +68,7 @@
 
     // ref : reference to 'then' function
     // cb, ec, cn : successCallback, failureCallback, notThennableCallback
-    var thennable = function (ref, cb, ec, cn) {
+    function thennable (ref, cb, ec, cn) {
       if (typeof val == 'object' && typeof ref == 'function') {
         try {
 
@@ -140,18 +140,10 @@
 
   }
 
-  // this object gets globalalized/exported
-
-  var promiz = {
-    // promise factory
-    defer: function () {
-      return new promise()
-    }
-  }
   // Export our library object, either for node.js or as a globally scoped variable
   if (typeof module != 'undefined') {
-    module['exports'] = promiz
+    module['exports'] = Deferred
   } else {
-    this['Promiz'] = promiz
+    this['Promiz'] = Deferred
   }
 })()

--- a/test/spec-adapter-micro.js
+++ b/test/spec-adapter-micro.js
@@ -1,14 +1,14 @@
-var Promiz = require('./../promiz.micro');
+var Deferred = require('./../promiz.micro');
 module.exports = {
   resolved: function (value) {
-    var d = Promiz.defer();
+    var d = new Deferred();
     d.resolve(value);
     return d;
   },
   rejected: function (error) {
-    var d = Promiz.defer();
+    var d = new Deferred();
     d.reject(error);
     return d;
   },
-  deferred: Promiz.defer
+  deferred: function () { return new Deferred(); },
 };


### PR DESCRIPTION
Since `defer` is the only export of the micro version, it might make sense to just export that.
This brings the gzipped version down to 227 bytes.

However, the interface changes because of this, which might or might not be acceptable.
